### PR TITLE
Querydsl support  for spring_data_jpa 1_9_0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-envers</artifactId>
-	<version>0.3.0.BUILD-SNAPSHOT</version>
+	<version>0.3.0.DSLQUERY-SNAPSHOT</version>
 
 	<name>Spring Data Envers</name>
 	<description>Spring Data extension to work with Hibernate Envers</description>
@@ -59,7 +59,7 @@
 
 	<properties>
 		<spring.version>4.0.9.RELEASE</spring.version>
-		<spring.data.jpa.version>1.8.0.RELEASE</spring.data.jpa.version>
+		<spring.data.jpa.version>1.9.0.RELEASE</spring.data.jpa.version>
 		<querydsl>3.6.2</querydsl>
 		<slf4j.version>1.7.10</slf4j.version>
 		<file.encoding>UTF-8</file.encoding>

--- a/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
@@ -99,17 +99,14 @@ public class EnversRevisionRepositoryFactoryBean extends
 	            RepositoryInformation information, EntityManager entityManager) {
 
 	        JpaEntityInformation<?, Serializable> entityInformation = getEntityInformation(information.getDomainType());
-	        
-	        //return getTargetRepository(entityInformation, entityManager);
 	        Class<?> repoBaseClass = information.getRepositoryBaseClass();
 	        SimpleJpaRepository<?, ?> result = null;
 	        if(RevisionRepository.class.isAssignableFrom(repoBaseClass)) {
 	            result = getTargetRepositoryViaReflection(information, entityInformation, revisionEntityInformation, entityManager);
 	        }
 	        else { 
-	          result = getTargetRepositoryViaReflection(information, entityInformation, entityManager);
+	          result = super.getTargetRepository(information, entityManager);
 	        }
-	        
 	        return result;
 	    }
 

--- a/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/envers/repository/support/EnversRevisionRepositoryFactoryBean.java
@@ -22,12 +22,14 @@ import javax.persistence.EntityManager;
 import org.hibernate.envers.DefaultRevisionEntity;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.core.GenericTypeResolver;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 import org.springframework.data.querydsl.QueryDslUtils;
+import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.history.RevisionRepository;
@@ -84,19 +86,46 @@ public class EnversRevisionRepositoryFactoryBean extends
 					: new ReflectionRevisionEntityInformation(revisionEntityClass);
 		}
 
+	    /**
+	     * Callback to create a {@link JpaRepository} instance with the given {@link EntityManager}
+	     * 
+	     * @param <T>
+	     * @param <ID>
+	     * @param entityManager
+	     * @see #getTargetRepository(RepositoryMetadata)
+	     * @return
+	     */
+	    protected <T, ID extends Serializable> SimpleJpaRepository<?, ?> getTargetRepository(
+	            RepositoryInformation information, EntityManager entityManager) {
+
+	        JpaEntityInformation<?, Serializable> entityInformation = getEntityInformation(information.getDomainType());
+	        
+	        //return getTargetRepository(entityInformation, entityManager);
+	        Class<?> repoBaseClass = information.getRepositoryBaseClass();
+	        SimpleJpaRepository<?, ?> result = null;
+	        if(RevisionRepository.class.isAssignableFrom(repoBaseClass)) {
+	            result = getTargetRepositoryViaReflection(information, entityInformation, revisionEntityInformation, entityManager);
+	        }
+	        else { 
+	          result = getTargetRepositoryViaReflection(information, entityInformation, entityManager);
+	        }
+	        
+	        return result;
+	    }
+
 		/* 
 		 * (non-Javadoc)
 		 * @see org.springframework.data.jpa.repository.support.JpaRepositoryFactory#getTargetRepository(org.springframework.data.repository.core.RepositoryMetadata, javax.persistence.EntityManager)
-		 */
+		 * /
 		@Override
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		protected <T, ID extends Serializable> SimpleJpaRepository<?, ?> getTargetRepository(RepositoryMetadata metadata,
-				EntityManager entityManager) {
+		    JpaEntityInformation<?, Serializable> entityInformation, EntityManager entityManager) {
 
 			JpaEntityInformation<T, Serializable> entityInformation = (JpaEntityInformation<T, Serializable>) getEntityInformation(metadata
 					.getDomainType());
 			return new EnversRevisionRepositoryImpl(entityInformation, revisionEntityInformation, entityManager);
-		}
+		}*/
 
 		/*
 		 * (non-Javadoc)


### PR DESCRIPTION
Modified factory-class to to support spring.data.jpa.version 1.9.0 by overriding the getTargetRepository to pass three args to the base-class constructor instead of the usual two in the parent class (JPARepositoryFactory).